### PR TITLE
fix definition handler for external dtos and enums

### DIFF
--- a/src/Facility.LanguageServer/FsdDefinitionUtility.cs
+++ b/src/Facility.LanguageServer/FsdDefinitionUtility.cs
@@ -23,8 +23,12 @@ namespace Facility.LanguageServer
 			{
 				case ServiceTypeKind.Dto:
 					return type.Dto!.Name;
+				case ServiceTypeKind.ExternalDto:
+					return type.ExternalDto!.Name;
 				case ServiceTypeKind.Enum:
 					return type.Enum!.Name;
+				case ServiceTypeKind.ExternalEnum:
+					return type.ExternalEnum!.Name;
 				case ServiceTypeKind.Array:
 				case ServiceTypeKind.Result:
 				case ServiceTypeKind.Map:


### PR DESCRIPTION
Based on how the `extern` keyword works (https://github.com/FacilityApi/Facility/pull/41#issue-1627863639):

>  ... it's sort of like a C extern. Facility does not resolve the type when generating source files. It trusts that what you put in as an extern type will exist. It's up to the project to ensure the specified types exist at build time.

It may not make sense to jump to another fsd file, which is what I originally hoped to accomplish. However, the definition handler should still at least jump to the definition with the `extern` keyword within the current file.

This is a simple fix, the language server is just resolving the name of the member with some internal code that was never updated after the `extern` keyword was added to the parser.