### PR TITLE
add document symbol handler

### DIFF
--- a/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
+++ b/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
@@ -4,7 +4,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Facility.LanguageServer
 {
@@ -22,116 +21,12 @@ namespace Facility.LanguageServer
 			if (service == null)
 				return null;
 
-			var symbols = new List<SymbolInformationOrDocumentSymbol>();
-			foreach (var member in service.Members)
-			{
-				var memberNamePart = member.GetPart(ServicePartKind.Name);
-				if (memberNamePart == null)
-					continue;
-
-				var symbolKind = member switch
-				{
-					ServiceMethodInfo => SymbolKind.Method,
-					ServiceDtoInfo => SymbolKind.Interface,
-					ServiceEnumInfo => SymbolKind.Enum,
-					ServiceExternalDtoInfo => SymbolKind.Interface,
-					ServiceExternalEnumInfo => SymbolKind.Enum,
-					ServiceErrorSetInfo => SymbolKind.Interface,
-					_ => SymbolKind.Null,
-				};
-
-				var maxColumn = memberNamePart.EndPosition.ColumnNumber;
-				var maxLine = memberNamePart.EndPosition.LineNumber;
-
-				var childSymbols = new List<DocumentSymbol>();
-				foreach (var child in member.GetDescendants().OfType<ServiceElementWithAttributesInfo>())
-				{
-					var childNamePart = child.GetPart(ServicePartKind.Name);
-					if (childNamePart == null)
-						continue;
-
-					maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
-					maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
-
-					var childTypePart = child.GetPart(ServicePartKind.TypeName);
-
-					var childName = child switch
-					{
-						ServiceFieldInfo field => field.Name,
-						ServiceErrorInfo error => error.Name,
-						_ => null,
-					};
-
-					if (childName == null)
-						continue;
-
-					var childSymbol = new DocumentSymbol
-					{
-						Name = childName,
-						Kind = SymbolKind.Field,
-						Range = new Range(
-							new Position(childNamePart.Position),
-							new Position(
-								new ServiceDefinitionPosition(
-									childName,
-									childTypePart?.EndPosition.LineNumber ?? childNamePart.EndPosition.LineNumber,
-									childTypePart?.EndPosition.ColumnNumber ?? childNamePart.EndPosition.ColumnNumber))),
-						SelectionRange = new Range(
-							new Position(childNamePart.Position),
-							new Position(childNamePart.EndPosition)),
-					};
-					childSymbols.Add(childSymbol);
-				}
-
-				foreach (var child in member.GetDescendants().OfType<ServiceEnumValueInfo>())
-				{
-					var childNamePart = child.GetPart(ServicePartKind.Name);
-					if (childNamePart == null)
-						continue;
-
-					maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
-					maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
-					var childSymbol = new DocumentSymbol
-					{
-						Name = child.Name,
-						Kind = SymbolKind.EnumMember,
-						Range = new Range(
-							new Position(childNamePart.Position),
-							new Position(childNamePart.EndPosition)),
-						SelectionRange = new Range(
-							new Position(childNamePart.Position),
-							new Position(childNamePart.EndPosition)),
-					};
-					childSymbols.Add(childSymbol);
-				}
-
-				var keywordPart = member.GetPart(ServicePartKind.Keyword);
-				var minColumn = keywordPart?.Position.ColumnNumber ?? memberNamePart.Position.ColumnNumber;
-				var minLine = keywordPart?.Position.LineNumber ?? memberNamePart.Position.LineNumber;
-
-				var symbol = new DocumentSymbol
-				{
-					Name = member.Name,
-					Kind = symbolKind,
-
-					Range = new Range(
-						new Position(
-							new ServiceDefinitionPosition(member.Name, minLine, minColumn)),
-						new Position(
-							new ServiceDefinitionPosition(member.Name, maxLine + 1, maxColumn))),
-					SelectionRange = new Range(
-						new Position(memberNamePart.Position),
-						new Position(memberNamePart.EndPosition)),
-					Children = childSymbols,
-				};
-				symbols.Add(symbol);
-			}
-
+			var symbols = service.GetServiceSymbols();
 			return symbols;
 		}
 
 		public DocumentSymbolRegistrationOptions GetRegistrationOptions(DocumentSymbolCapability capability, ClientCapabilities clientCapabilities)
-			=> new DocumentSymbolRegistrationOptions
+			=> new()
 			{
 				DocumentSelector = DocumentSelector.ForLanguage("fsd"),
 			};

--- a/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
+++ b/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
@@ -1,0 +1,107 @@
+using Facility.Definition;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Facility.LanguageServer
+{
+	internal sealed class FsdDocumentSymbolHandler : FsdRequestHandler, IDocumentSymbolHandler
+	{
+		public FsdDocumentSymbolHandler(ILanguageServerFacade router, ILanguageServerConfiguration configuration, IDictionary<DocumentUri, ServiceInfo> serviceInfos)
+			: base(router, configuration, serviceInfos)
+		{
+		}
+
+		public async Task<SymbolInformationOrDocumentSymbolContainer> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
+		{
+			var documentUri = request.TextDocument.Uri;
+			var service = GetService(documentUri);
+			if (service == null)
+				return null;
+
+			var symbols = new List<SymbolInformationOrDocumentSymbol>();
+			foreach (var member in service.Members)
+			{
+				var memberNamePart = member.GetPart(ServicePartKind.Name);
+				if (memberNamePart == null)
+					continue;
+
+				var symbolKind = member switch
+				{
+					ServiceMethodInfo => SymbolKind.Method,
+					ServiceDtoInfo => SymbolKind.Interface,
+					ServiceEnumInfo => SymbolKind.Enum,
+					ServiceExternalDtoInfo => SymbolKind.Interface,
+					ServiceExternalEnumInfo => SymbolKind.Enum,
+					_ => SymbolKind.Null,
+				};
+
+				var maxColumn = memberNamePart.EndPosition.ColumnNumber;
+				var maxLine = memberNamePart.EndPosition.LineNumber;
+
+				var childSymbols = new List<DocumentSymbol>();
+				foreach (var child in member.GetDescendants().OfType<ServiceFieldInfo>())
+				{
+					var childNamePart = child.GetPart(ServicePartKind.Name);
+					if (childNamePart == null)
+						continue;
+
+					maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
+					maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
+					var childSymbol = new DocumentSymbol
+					{
+						Name = child.Name,
+						Kind = SymbolKind.Field,
+						Range = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+						SelectionRange = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+					};
+					childSymbols.Add(childSymbol);
+				}
+
+				foreach (var child in member.GetDescendants().OfType<ServiceEnumValueInfo>())
+				{
+					var childNamePart = child.GetPart(ServicePartKind.Name);
+					if (childNamePart == null)
+						continue;
+
+					maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
+					maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
+					var childSymbol = new DocumentSymbol
+					{
+						Name = child.Name,
+						Kind = SymbolKind.EnumMember,
+						Range = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+						SelectionRange = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+					};
+					childSymbols.Add(childSymbol);
+				}
+
+				var keywordPart = member.GetPart(ServicePartKind.Keyword);
+				var minColumn = keywordPart?.Position.ColumnNumber ?? memberNamePart.Position.ColumnNumber;
+				var minLine = keywordPart?.Position.LineNumber ?? memberNamePart.Position.LineNumber;
+
+				var symbol = new DocumentSymbol
+				{
+					Name = member.Name,
+					Kind = symbolKind,
+
+					Range = new Range(new Position(new ServiceDefinitionPosition(member.Name, minLine, minColumn)), new Position(new ServiceDefinitionPosition(member.Name, maxLine + 1, maxColumn))),
+					SelectionRange = new Range(new Position(memberNamePart.Position), new Position(memberNamePart.EndPosition)),
+					Children = childSymbols,
+				};
+				symbols.Add(symbol);
+			}
+
+			return symbols;
+		}
+
+		public DocumentSymbolRegistrationOptions GetRegistrationOptions(DocumentSymbolCapability capability, ClientCapabilities clientCapabilities)
+			=> new DocumentSymbolRegistrationOptions
+			{
+				DocumentSelector = DocumentSelector.ForLanguage("fsd"),
+			};
+	}
+}

--- a/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
+++ b/src/Facility.LanguageServer/FsdDocumentSymbolHandler.cs
@@ -51,12 +51,23 @@ namespace Facility.LanguageServer
 
 					maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
 					maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
+
+					var childTypePart = child.GetPart(ServicePartKind.TypeName);
+
 					var childSymbol = new DocumentSymbol
 					{
 						Name = child.Name,
 						Kind = SymbolKind.Field,
-						Range = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
-						SelectionRange = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+						Range = new Range(
+							new Position(childNamePart.Position),
+							new Position(
+								new ServiceDefinitionPosition(
+									child.Name,
+									childTypePart?.EndPosition.LineNumber ?? childNamePart.EndPosition.LineNumber,
+									childTypePart?.EndPosition.ColumnNumber ?? childNamePart.EndPosition.ColumnNumber))),
+						SelectionRange = new Range(
+							new Position(childNamePart.Position),
+							new Position(childNamePart.EndPosition)),
 					};
 					childSymbols.Add(childSymbol);
 				}
@@ -73,8 +84,12 @@ namespace Facility.LanguageServer
 					{
 						Name = child.Name,
 						Kind = SymbolKind.EnumMember,
-						Range = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
-						SelectionRange = new Range(new Position(childNamePart.Position), new Position(childNamePart.EndPosition)),
+						Range = new Range(
+							new Position(childNamePart.Position),
+							new Position(childNamePart.EndPosition)),
+						SelectionRange = new Range(
+							new Position(childNamePart.Position),
+							new Position(childNamePart.EndPosition)),
 					};
 					childSymbols.Add(childSymbol);
 				}
@@ -88,8 +103,14 @@ namespace Facility.LanguageServer
 					Name = member.Name,
 					Kind = symbolKind,
 
-					Range = new Range(new Position(new ServiceDefinitionPosition(member.Name, minLine, minColumn)), new Position(new ServiceDefinitionPosition(member.Name, maxLine + 1, maxColumn))),
-					SelectionRange = new Range(new Position(memberNamePart.Position), new Position(memberNamePart.EndPosition)),
+					Range = new Range(
+						new Position(
+							new ServiceDefinitionPosition(member.Name, minLine, minColumn)),
+						new Position(
+							new ServiceDefinitionPosition(member.Name, maxLine + 1, maxColumn))),
+					SelectionRange = new Range(
+						new Position(memberNamePart.Position),
+						new Position(memberNamePart.EndPosition)),
 					Children = childSymbols,
 				};
 				symbols.Add(symbol);

--- a/src/Facility.LanguageServer/FsdSymbolUtility.cs
+++ b/src/Facility.LanguageServer/FsdSymbolUtility.cs
@@ -1,0 +1,118 @@
+using Facility.Definition;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Facility.LanguageServer;
+
+internal static class FsdSymbolUtility
+{
+	public static List<SymbolInformationOrDocumentSymbol> GetServiceSymbols(this ServiceInfo service)
+	{
+		var symbols = new List<SymbolInformationOrDocumentSymbol>();
+		foreach (var member in service.Members)
+		{
+			var memberNamePart = member.GetPart(ServicePartKind.Name);
+			if (memberNamePart == null)
+				continue;
+
+			var symbolKind = member switch
+			{
+				ServiceMethodInfo => SymbolKind.Method,
+				ServiceDtoInfo => SymbolKind.Interface,
+				ServiceEnumInfo => SymbolKind.Enum,
+				ServiceExternalDtoInfo => SymbolKind.Interface,
+				ServiceExternalEnumInfo => SymbolKind.Enum,
+				ServiceErrorSetInfo => SymbolKind.Interface,
+				_ => SymbolKind.Null,
+			};
+
+			var maxColumn = memberNamePart.EndPosition.ColumnNumber;
+			var maxLine = memberNamePart.EndPosition.LineNumber;
+
+			var childSymbols = new List<DocumentSymbol>();
+			foreach (var child in member.GetDescendants().OfType<ServiceElementWithAttributesInfo>())
+			{
+				var childNamePart = child.GetPart(ServicePartKind.Name);
+				if (childNamePart == null)
+					continue;
+
+				maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
+				maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
+
+				var childTypePart = child.GetPart(ServicePartKind.TypeName);
+
+				var childName = child switch
+				{
+					ServiceFieldInfo field => field.Name,
+					ServiceErrorInfo error => error.Name,
+					_ => null,
+				};
+
+				if (childName == null)
+					continue;
+
+				var childSymbol = new DocumentSymbol
+				{
+					Name = childName,
+					Kind = SymbolKind.Field,
+					Range = new Range(
+						new Position(childNamePart.Position),
+						new Position(
+							new ServiceDefinitionPosition(
+								childName,
+								childTypePart?.EndPosition.LineNumber ?? childNamePart.EndPosition.LineNumber,
+								childTypePart?.EndPosition.ColumnNumber ?? childNamePart.EndPosition.ColumnNumber))),
+					SelectionRange = new Range(
+						new Position(childNamePart.Position),
+						new Position(childNamePart.EndPosition)),
+				};
+				childSymbols.Add(childSymbol);
+			}
+
+			foreach (var child in member.GetDescendants().OfType<ServiceEnumValueInfo>())
+			{
+				var childNamePart = child.GetPart(ServicePartKind.Name);
+				if (childNamePart == null)
+					continue;
+
+				maxColumn = Math.Max(maxColumn, childNamePart.EndPosition.ColumnNumber);
+				maxLine = Math.Max(maxLine, childNamePart.EndPosition.LineNumber);
+				var childSymbol = new DocumentSymbol
+				{
+					Name = child.Name,
+					Kind = SymbolKind.EnumMember,
+					Range = new Range(
+						new Position(childNamePart.Position),
+						new Position(childNamePart.EndPosition)),
+					SelectionRange = new Range(
+						new Position(childNamePart.Position),
+						new Position(childNamePart.EndPosition)),
+				};
+				childSymbols.Add(childSymbol);
+			}
+
+			var keywordPart = member.GetPart(ServicePartKind.Keyword);
+			var minColumn = keywordPart?.Position.ColumnNumber ?? memberNamePart.Position.ColumnNumber;
+			var minLine = keywordPart?.Position.LineNumber ?? memberNamePart.Position.LineNumber;
+
+			var symbol = new DocumentSymbol
+			{
+				Name = member.Name,
+				Kind = symbolKind,
+
+				Range = new Range(
+					new Position(
+						new ServiceDefinitionPosition(member.Name, minLine, minColumn)),
+					new Position(
+						new ServiceDefinitionPosition(member.Name, maxLine + 1, maxColumn))),
+				SelectionRange = new Range(
+					new Position(memberNamePart.Position),
+					new Position(memberNamePart.EndPosition)),
+				Children = childSymbols,
+			};
+			symbols.Add(symbol);
+		}
+
+		return symbols;
+	}
+}

--- a/src/Facility.LanguageServer/Program.cs
+++ b/src/Facility.LanguageServer/Program.cs
@@ -28,6 +28,7 @@ var server = await LanguageServer.From(
 			.WithHandler<FsdDefinitionHandler>()
 			.WithHandler<FsdReferenceHandler>()
 			.WithHandler<FsdHoverHandler>()
+			.WithHandler<FsdDocumentSymbolHandler>()
 			.WithServices(
 				x => x
 					.AddLogging(b => b.SetMinimumLevel(LogLevel.Trace)))).ConfigureAwait(false);


### PR DESCRIPTION
This can be tested with the vscode extension using the breadcrumbs. It should update based on the cursor position and you would be able to click the breadcrumb and navigate. Symbols should be nested as expected. The icon should indicate the type, but also hovering with the mouse shows a tooltip.

![Screenshot 2023-12-01 at 12 38 40 PM](https://github.com/FacilityApi/FacilityLanguageServer/assets/9691017/f7f3073a-37fb-435c-834b-d19b97e9d29f)

![Screenshot 2023-12-01 at 12 39 14 PM](https://github.com/FacilityApi/FacilityLanguageServer/assets/9691017/5456e683-28dd-4e5d-8e80-d46f205cf34c)

![Screenshot 2023-12-01 at 12 41 57 PM](https://github.com/FacilityApi/FacilityLanguageServer/assets/9691017/65ea2d6d-3dd4-4398-b1aa-2be24bc51feb)