### PR TITLE
Rename handler

### DIFF
--- a/src/Facility.LanguageServer/FsdDefinitionUtility.cs
+++ b/src/Facility.LanguageServer/FsdDefinitionUtility.cs
@@ -71,7 +71,7 @@ namespace Facility.LanguageServer
 
 					return (part, name);
 				})
-				.Where(x => x.part != null && x.name == fieldTypeNameAtCursor)
+				.Where(x => x.part != null && (x.name == fieldTypeNameAtCursor || x.name == memberAtCursor.name))
 				.Select(x => x.part);
 
 			return includeDeclaration

--- a/src/Facility.LanguageServer/FsdDefinitionUtility.cs
+++ b/src/Facility.LanguageServer/FsdDefinitionUtility.cs
@@ -58,10 +58,10 @@ namespace Facility.LanguageServer
 					var type = service.GetFieldType(field);
 					var memberTypeName = type?.GetMemberTypeName();
 
-					return (part, memberTypeName, typeName);
+					return (part, memberTypeName, typeName, type);
 				})
 				.Where(x => x.part != null && ((memberAtCursor.name != null && x.memberTypeName == memberAtCursor.name) || x.typeName == fieldTypeNameAtCursor))
-				.Select(x => x.part);
+				.Select(x => GetPositionWithoutArrayBrackets(x.part, x.type));
 
 			var referencedMembers = members
 				.Select(member =>
@@ -108,5 +108,10 @@ namespace Facility.LanguageServer
 
 			return type?.ToString() ?? field.TypeName;
 		}
+
+		public static ServicePart GetPositionWithoutArrayBrackets(ServicePart part, ServiceTypeInfo type) =>
+			type.Kind == ServiceTypeKind.Array
+				? new ServicePart(part.Kind, part.Position, new ServiceDefinitionPosition(part.EndPosition.Name, part.EndPosition.LineNumber, part.EndPosition.ColumnNumber - 2))
+				: part;
 	}
 }

--- a/src/Facility.LanguageServer/FsdRenameHandler.cs
+++ b/src/Facility.LanguageServer/FsdRenameHandler.cs
@@ -57,7 +57,7 @@ internal sealed class FsdRenameHandler : FsdRequestHandler, IRenameHandler, IPre
 				var type = service.GetFieldType(field);
 				var part = field.GetPart(ServicePartKind.TypeName);
 
-				if (type is null || part is null || !m_isRenamable.Contains(type.Kind))
+				if (type is null || part is null || !s_isRenamable.Contains(type.Kind))
 					return null;
 
 				part = FsdDefinitionUtility.GetPositionWithoutArrayBrackets(part, type);
@@ -106,7 +106,7 @@ internal sealed class FsdRenameHandler : FsdRequestHandler, IRenameHandler, IPre
 		};
 	}
 
-	private readonly HashSet<ServiceTypeKind> m_isRenamable = new()
+	private static readonly HashSet<ServiceTypeKind> s_isRenamable = new()
 	{
 		ServiceTypeKind.Dto,
 		ServiceTypeKind.ExternalDto,

--- a/src/Facility.LanguageServer/Program.cs
+++ b/src/Facility.LanguageServer/Program.cs
@@ -20,17 +20,15 @@ var server = await LanguageServer.From(
 			.ConfigureLogging(
 				x => x
 					.AddLanguageProtocolLogging()
-					.SetMinimumLevel(LogLevel.Debug))
+					.SetMinimumLevel(LogLevel.Information))
 			.WithServices(
 				services => services
 					.AddSingleton<IDictionary<DocumentUri, ServiceInfo>>(serviceInfos))
 			.WithHandler<FsdSyncHandler>()
 			.WithHandler<FsdDefinitionHandler>()
 			.WithHandler<FsdReferenceHandler>()
+			.WithHandler<FsdRenameHandler>()
 			.WithHandler<FsdHoverHandler>()
-			.WithHandler<FsdDocumentSymbolHandler>()
-			.WithServices(
-				x => x
-					.AddLogging(b => b.SetMinimumLevel(LogLevel.Trace)))).ConfigureAwait(false);
+			.WithHandler<FsdDocumentSymbolHandler>()).ConfigureAwait(false);
 
 await server.WaitForExit.ConfigureAwait(false);


### PR DESCRIPTION
Obviously renaming isn't something that should be done carelessly in a service, but when you actually want to do this, no reason why is can't be easy.

https://github.com/FacilityApi/FacilityLanguageServer/commit/bbbf55d3546295cdb9e20275840786f2536f7520 fixes a bug so if we don't want to merge this, I can split it into a separate pr.

Also I can revert the logging changes if we don't want those. Just felt like they were noisy.